### PR TITLE
Fixes/updates for SPI flash systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ This repository contains boot-related tools for Tegra platforms.
 
 ## tegra-bootinfo
 The `tegra-bootinfo` tool provides a simple boot-count mechanism for
-Tegra platforms that do not use U-Boot as an intermediate bootloader
-Jetson TX2 and Jetson Xavier systems.
+Tegra platforms that do not use U-Boot as an intermediate bootloader,
+such as Jetson TX2 and Jetson AGX Xavier/Xavier NX systems.
 
 The native bootloaders on the TX2 and Xavier have some support for
 automatic failover in the event of a boot failure, but they give up
@@ -14,7 +14,8 @@ if the device runs unattended and is possibly subject to power outages
 that can happen at boot time.
 
 The `tega-bootinfo` tool is intended to be run from the initrd on
-these systems. It records (in a sector of the eMMC) that a boot is
+these systems. It records (in a sector of the eMMC, or in the QSPI
+boot flash on Xavier NX development kits) that a boot is
 in progress, and can be accompanied by an invocation of the `nvbootctrl`
 tool to notify the NVIDIA bootloader that the boot was successful.
 A second invocation of `tegra-bootinfo` should be used at (or close to)
@@ -30,6 +31,11 @@ from a recovery partition.
 The tool also supports storage and retrieval of named strings, similar
 to U-Boot environment variables. The number of flash sectors allocated
 for variable storage is configurable at build time.
+
+On T210 (Jetson TX1 and Nano) systems, U-Boot can be configured provide
+the boot count mechanism and appropriate failover behavior.  This tool
+will work on those systems as well, however.
+
 
 ## tegra-bootloader-update
 This tool can be used to parse a bootloader update (BUP) payload generated

--- a/configure.ac
+++ b/configure.ac
@@ -4,9 +4,9 @@ dnl
 dnl Copyright (c) 2019, 2020 Matthew Madison
 dnl
 
-AC_INIT([tegra-boot-tools], [1.4.0])
+AC_INIT([tegra-boot-tools], [1.5.0])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAJOR], [1], [Major version])
-AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [4], [Minor version])
+AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [5], [Minor version])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [0], [Maintenance level])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])

--- a/gpt.c
+++ b/gpt.c
@@ -51,6 +51,7 @@ struct gpt_context_s {
 	unsigned int blocksize;
 	off_t devsize;
 	void *buffer;
+	int is_mmcboot1;
 	int primary_valid, backup_valid;
 	struct gpt_header_s primary_header;
 	struct gpt_header_s backup_header;
@@ -86,6 +87,7 @@ gpt_init (const char *devname, unsigned int blocksize)
 		free(ctx);
 		return NULL;
 	}
+	ctx->is_mmcboot1 = strcmp(devname, "/dev/mmcblk0boot1") == 0;
 	ctx->fd = fd;
 	ctx->blocksize = blocksize;
 	ctx->devsize = lseek(fd, 0, SEEK_END);
@@ -191,7 +193,7 @@ gpt_load (gpt_context_t *ctx, unsigned int flags)
 	 * In the NVIDIA-special pseudo-GPT in mmblk0boot1, it counts the LBAs in
 	 * both boot blocks together as if they were a single device.
 	 */
-	if (flags & GPT_NVIDIA_SPECIAL)
+	if (ctx->is_mmcboot1 && (flags & GPT_NVIDIA_SPECIAL) != 0)
 		startpos -= ctx->devsize;
 	startpos = lseek(fd, startpos, SEEK_SET);
 	if (startpos == (off_t) -1)

--- a/tegra-bootloader-update.c
+++ b/tegra-bootloader-update.c
@@ -190,6 +190,7 @@ update_bct (int bootfd, void *curbct, struct update_entry_s *ent)
 		}
 	}
 
+	fsync(bootfd);
 	bct_updated = 1;
 	printf("[OK]\n");
 	return 0;
@@ -250,6 +251,7 @@ maybe_update_bootpart (int bootfd, struct update_entry_s *ent, int is_bct)
 		}
 	}
 
+	fsync(bootfd);
 	printf("[OK]\n");
 	return 0;
 

--- a/tegra-bootloader-update.c
+++ b/tegra-bootloader-update.c
@@ -266,7 +266,8 @@ process_entry (bup_context_t *bupctx, int bootfd, struct update_entry_s *ent, in
 	ssize_t n, total, remain;
 	int fd;
 
-	printf("  Processing %s:...", ent->partname);
+	printf("  Processing %s... ", ent->partname);
+	fflush(stdout);
 	if (bup_setpos(bupctx, ent->bup_offset) == (off_t) -1) {
 		printf("[FAIL]\n");
 		fprintf(stderr, "could not set position for %s\n", ent->partname);


### PR DESCRIPTION
* `tegra-bootloader-update` now works correctly on Xavier NX devices
* `tegra-bootinfo` adds support for storing its data in SPI flash if no eMMC is available (fixes #5)