### PR TITLE
Add support for bootloader updates on TX1/Nano and fix issues with updates on secureboot-enabled devices

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -114,6 +114,6 @@ config-files/bootcountcheck.service: config-files/bootcountcheck.service.in Make
 tmpfiles_DATA = config-files/tegra-bootinfo.conf
 tbt_DATA = config-files/machine-name.conf config-files/rootfsdev.conf
 
-dist_sbin_SCRIPTS = scripts/bootcountcheck
+dist_sbin_SCRIPTS = scripts/bootcountcheck scripts/nvbootctrl scripts/nv_update_engine
 
 CLEANFILES = $(systemdsystemunit_DATA)

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ tbtinc_HEADERS = smd.h gpt.h bup.h
 pkgconfig_DATA = tegra-boot-tools.pc
 
 bin_PROGRAMS = tegra-bootloader-update tegra-boot-control tegra-bootinfo
-tegra_bootloader_update_SOURCES = tegra-bootloader-update.c bct_t18x.c bct_t19x.c bct.h \
+tegra_bootloader_update_SOURCES = tegra-bootloader-update.c bct_t18x.c bct_t19x.c bct_t21x.c bct.h \
     nvidia/nvcommon.h \
     nvidia/t18x/arse0.h \
     nvidia/t18x/nvboot_crypto_signatures.h \

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ will work on those systems as well, however.
 ## tegra-bootloader-update
 This tool can be used to parse a bootloader update (BUP) payload generated
 by the Tegra flashing tools, as well as program the appropriate contents
-of a BUP payload into the boot partitions on a tegra186 (Jetson TX2) or
-tegra194 (Jetson Xavier) device. It can replace the `nv_update_engine`
-tool provided in the L4T BSP.
+of a BUP payload into the boot partitions. It can replace the
+`nv_update_engine` tool provided in the L4T BSP for tegra186/tegra194
+platforms, and the `l4t_payload_updater_t210` tool on tegra210
+platforms.
 
 ### Differences from `nv_update_engine`
 
@@ -61,9 +62,18 @@ tool provided in the L4T BSP.
 * This tool automatically enables A/B redundancy during an update if
   it has not yet been enabled.
 
+### Differences from `l4t_payload_updater_t210`
+
+* Written in C, rather than Python.
+* Boot partition information is read from a configuration file at
+  runtime, rather than being hard-coded into the tool.
+* Automatically handles either SPI flash or eMMC boot partitions,
+  without depending on the MACHINE name as the Python tool does.
+
 ## tegra-boot-control
 This tool replaces the `nvbootctrl` program provided with the L4T BSP,
-and can be used to display or modify the boot slots.
+and can be used to display or modify the boot slots on a tegra186
+or tegra194-based platform.
 
 ### Differences from `nvbootctrl`
 
@@ -85,6 +95,11 @@ files needed to configure and build.
 ## Dependencies
 This package depends on systemd, libz, and
 [tegra-eeprom-tool](https://github.com/OE4T/tegra-eeprom-tool).
+
+For tegra210-based platforms, a configuration file enumerating the
+boot partitions, with offsets and sizes, is expected at runtime.
+This file should be generated from the flash layout XML file for
+the target.
 
 # License
 Distributed under license. See the [LICENSE](LICENSE) file for details.

--- a/bct.h
+++ b/bct.h
@@ -4,5 +4,6 @@
 
 int bct_update_valid_t18x(void *cur_bct, void *cand_bct, unsigned int *block_size, unsigned int *page_size);
 int bct_update_valid_t19x(void *cur_bct, void *cand_bct, unsigned int *block_size, unsigned int *page_size);
+int bct_update_valid_t21x(void *cur_bct, void *cand_bct, unsigned int *block_size, unsigned int *page_size);
 
 #endif /* bct_h__ */

--- a/bct.h
+++ b/bct.h
@@ -2,8 +2,8 @@
 #define bct_h__
 /* Copyright (c) 2020 Matthew Madison */
 
-int bct_update_valid_t18x(void *cur_bct, void *cand_bct, unsigned int *block_size, unsigned int *page_size);
-int bct_update_valid_t19x(void *cur_bct, void *cand_bct, unsigned int *block_size, unsigned int *page_size);
+int bct_update_valid_t18x(void *cur_bct, void *cand_bct);
+int bct_update_valid_t19x(void *cur_bct, void *cand_bct);
 int bct_update_valid_t21x(void *cur_bct, void *cand_bct, unsigned int *block_size, unsigned int *page_size);
 
 #endif /* bct_h__ */

--- a/bct_t18x.c
+++ b/bct_t18x.c
@@ -12,9 +12,7 @@
  * bct_update_valid_t18x
  */
 int
-bct_update_valid_t18x (void *cur_bct, void *cand_bct,
-		       unsigned int *block_size,
-		       unsigned int *page_size)
+bct_update_valid_t18x (void *cur_bct, void *cand_bct)
 {
 	NvBootConfigTable *cur = cur_bct;
 	NvBootConfigTable *cand = cand_bct;
@@ -25,10 +23,8 @@ bct_update_valid_t18x (void *cur_bct, void *cand_bct,
 		return 0;
 	if (cur->BlockSizeLog2 != cand->BlockSizeLog2)
 		return 0;
-	*block_size = (1U << cur->BlockSizeLog2);
 	if (cur->PageSizeLog2 != cand->PageSizeLog2)
 		return 0;
-	*page_size = (1U << cur->PageSizeLog2);
 
 	return 1;
 

--- a/bct_t19x.c
+++ b/bct_t19x.c
@@ -12,9 +12,7 @@
  * bct_update_valid_t19x
  */
 int
-bct_update_valid_t19x (void *cur_bct, void *cand_bct,
-		       unsigned int *block_size,
-		       unsigned int *page_size)
+bct_update_valid_t19x (void *cur_bct, void *cand_bct)
 {
 	NvBootConfigTable *cur = cur_bct;
 	NvBootConfigTable *cand = cand_bct;
@@ -25,10 +23,8 @@ bct_update_valid_t19x (void *cur_bct, void *cand_bct,
 		return 0;
 	if (cur->BlockSizeLog2 != cand->BlockSizeLog2)
 		return 0;
-	*block_size = (1U << cur->BlockSizeLog2);
 	if (cur->PageSizeLog2 != cand->PageSizeLog2)
 		return 0;
-	*page_size = (1U << cur->PageSizeLog2);
 
 	return 1;
 

--- a/bct_t21x.c
+++ b/bct_t21x.c
@@ -1,0 +1,32 @@
+/*
+ * bct_t21x.c
+ *
+ * BCT-related functions for t21x SoCs
+ *
+ * Copyright (c) 2020 Matthew Madison
+ */
+#include <stdint.h>
+
+#define BOOT_BLOCK_SIZE_LOG_2 333
+#define BOOT_PAGE_SIZE_LOG_2  334
+
+/*
+ * bct_update_valid_t21x
+ */
+int
+bct_update_valid_t21x (void *cur_bct, void *cand_bct,
+		       unsigned int *block_size,
+		       unsigned int *page_size)
+{
+	uint32_t *cur = cur_bct;
+	uint32_t *cand = cand_bct;
+
+	if (cur[BOOT_BLOCK_SIZE_LOG_2] != cand[BOOT_BLOCK_SIZE_LOG_2] ||
+	    cur[BOOT_PAGE_SIZE_LOG_2] != cand[BOOT_PAGE_SIZE_LOG_2])
+		return 0;
+	*block_size = (1U << cur[BOOT_BLOCK_SIZE_LOG_2]);
+	*page_size = (1U << cur[BOOT_PAGE_SIZE_LOG_2]);
+
+	return 1;
+
+} /* bct_update_valid_t21x */

--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,10 @@ dnl
 dnl Copyright (c) 2019, 2020 Matthew Madison
 dnl
 
-AC_INIT([tegra-boot-tools], [2.0.1])
+AC_INIT([tegra-boot-tools], [2.1.0])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAJOR], [2], [Major version])
-AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [0], [Minor version])
-AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [1], [Maintenance level])
+AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [1], [Minor version])
+AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [0], [Maintenance level])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
 AC_COPYRIGHT([

--- a/configure.ac
+++ b/configure.ac
@@ -49,8 +49,8 @@ AC_ARG_WITH([gptdev],
     [], [with_gptdev=/dev/mmcblk0boot1])
 AC_DEFINE_UNQUOTED([OTAGPTDEV], ["$with_gptdev"], [Device where pseudo-GPT for boot partitions is stored])
 AC_ARG_WITH([extended-sector-count],
-    AS_HELP_STRING([--with-extended-sector-count=N], [number of 512-byte sectors for boot variable storage]),
-    [], [with_extended_sector_count=1])
+    AS_HELP_STRING([--with-extended-sector-count=N], [number of extra 512-byte sectors for boot variable storage]),
+    [], [with_extended_sector_count=15])
 AC_DEFINE_UNQUOTED([EXTENSION_SECTOR_COUNT], [$with_extended_sector_count], [Number of extension sectors])
 
 PKG_PROG_PKG_CONFIG([0.29])

--- a/gpt.h
+++ b/gpt.h
@@ -19,11 +19,13 @@ typedef struct gpt_entry_s gpt_entry_t;
 
 gpt_context_t *gpt_init(const char *devname, unsigned int blocksize);
 void gpt_finish(gpt_context_t *ctx);
+int gpt_fd(gpt_context_t *ctx);
 
 #define GPT_LOAD_BACKUP_ONLY	(1<<0)
 #define GPT_NVIDIA_SPECIAL	(1<<1)
 
 int gpt_load(gpt_context_t *ctx, unsigned int flags);
+int gpt_load_from_config(gpt_context_t *ctx);
 
 gpt_entry_t *gpt_find_by_name(gpt_context_t *ctx, const char *name);
 gpt_entry_t *gpt_enumerate_partitions(gpt_context_t *ctx, void **iterctx);

--- a/scripts/bootcountcheck
+++ b/scripts/bootcountcheck
@@ -1,4 +1,5 @@
 #!/bin/sh
+tegra-bootinfo --initialize
 tegra-bootinfo --check-status
 if [ $? = 77 ]; then
     curslot=$(tegra-boot-control --current-slot)

--- a/scripts/nv_update_engine
+++ b/scripts/nv_update_engine
@@ -1,0 +1,59 @@
+#!/bin/sh
+usage() {
+    cat >&2 <<EOF
+NV emulation wrapper for tegra-bootloader-update
+
+Usage:
+	nv_update_engine
+
+Options:
+-i, --install          install update (add 'no-reboot' to prevent reboot)
+-v, --verify           NOT IMPLEMENTED
+-d, --disable-ab       disable redundancy
+-e, --enable-ab        enable redundancy
+-h, --help             display this help
+EOF
+}
+
+ARGS=$(getopt -n $(basename "$0") -l "install,verify,disable-ab,enable-ab,help" -o "i::vdeh" -- "$@")
+if [ $? -ne 0 ]; then
+    usage
+    exit 1
+fi
+eval set -- "$ARGS"
+unset ARGS
+# After getopt parsing:
+# $1 must be one of the options
+# $2 must be -- (i.e., no more options)
+if [ "$2" != "--" ]; then
+    usage
+    exit 1
+fi
+
+case "$1" in
+    --install|-i)
+	if [ -n "$3" -a "$3" != "no-reboot" ]; then
+	    usage
+	    exit 1
+	fi
+	tegra-bootloader-update /opt/ota_package/bl_update_payload
+	[ "$3" = "no-reboot" ] || reboot
+	;;
+    --disable-ab|-d)
+	tegra-boot-control --disable
+	;;
+    --enable-ab|-e)
+	tegra-boot-control --enable
+	;;
+    --verify|-v)
+	echo "Note: verify not implemented" >&2
+	;;
+    --help|-h)
+	usage
+	;;
+    *)
+	echo "Error processing options" >&2
+	usage
+	exit 1
+	;;
+esac

--- a/scripts/nvbootctrl
+++ b/scripts/nvbootctrl
@@ -1,0 +1,66 @@
+#!/bin/sh
+usage() {
+cat >&2 <<EOF
+nvbootctrl - NV compatibility interface to tegra-boot-control
+
+Commands:
+  nvbootctrl get-number-slots
+  nvbootctrl get-current-slot
+  nvbootctrl mark-boot-successful
+  nvbootctrl set-active-boot-slot SLOT
+  nvbootctrl set-slot-as-unbootable SLOT     -- NOT IMPLEMENTED
+  nvbootctrl is-slot-bootable SLOT           -- NOT IMPLEMENTED
+  nvbootctrl is-slot-marked-successful SLOT  -- NOT IMPLEMENTED
+  nvbootctrl get-suffix SLOT
+  nvbootctrl dump-slots-info
+EOF
+}
+
+cmd="$1"
+slot="$2"
+
+if [ -z "$cmd" ]; then
+    usage
+    exit 1
+fi
+
+case $cmd in
+    get-number-slots)
+	if tegra-boot-control --status | grep -q '^Redundancy: disabled'; then
+	    echo 1
+	else
+	    echo 2
+	fi
+	;;
+    get-current-slot)
+	tegra-boot-control --current-slot
+	;;
+    mark-boot-successful)
+	tegra-boot-control --mark-successful
+	;;
+    set-active-boot-slot)
+	if [ -n "$slot" ]; then
+	    tegra-boot-control --set-active $slot
+	else
+	    usage
+	    exit 1
+	fi
+	;;
+    get-suffix)
+	if [ "$slot" = "0" ]; then
+	    echo ""
+	elif [ "$slot" = "1" ]; then
+	    echo "_b"
+	else
+	    usage
+	    exit 1
+	fi
+	;;
+    dump-slots-info)
+	tegra-boot-control --status
+	;;
+    *)
+	usage
+	exit 1
+	;;
+esac

--- a/tegra-boot-control.c
+++ b/tegra-boot-control.c
@@ -167,7 +167,7 @@ main (int argc, char * const argv[])
 	int c, which, fd;
 	int reset_bootdev;
 	int curslot;
-	unsigned int selected_slot;
+	unsigned int selected_slot = 0;
 	int result = 1;
 	tegra_soctype_t soctype;
 	gpt_context_t *gptctx;

--- a/tegra-bootinfo.c
+++ b/tegra-bootinfo.c
@@ -930,11 +930,12 @@ show_bootinfo(void) {
 	printf("devinfo version:        %u\n"
 	       "Boot in progress:       %s\n"
 	       "Failed boots:           %d\n"
-	       "Extension space:        %d sectors\n",
+	       "Extension space:        %d sector%s\n",
 	       ctx->curinfo.devinfo_version,
 	       (ctx->curinfo.flags & FLAG_BOOT_IN_PROGRESS) ? "YES" : "NO",
 	       ctx->curinfo.failed_boots,
-	       ctx->curinfo.ext_sectors);
+	       ctx->curinfo.ext_sectors,
+	       (ctx->curinfo.ext_sectors == 1 ? "" : "s"));
 	close_bootinfo(ctx, 0);
 	return 0;
 

--- a/tegra-bootloader-update.c
+++ b/tegra-bootloader-update.c
@@ -4,11 +4,12 @@
  * Tool for updating/initializing Tegra boot partitions
  * using a BUP package.
  *
- * Copyright (c) 2019, Matthew Madison
+ * Copyright (c) 2019-2020, Matthew Madison
  */
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <getopt.h>
 #include <string.h>
@@ -56,6 +57,11 @@ struct update_entry_s {
 	size_t length;
 };
 
+struct update_list_s {
+	unsigned int count;
+	const char **partnames;
+};
+
 #define MAX_ENTRIES 64
 static struct update_entry_s redundant_entries[MAX_ENTRIES];
 static struct update_entry_s nonredundant_entries[MAX_ENTRIES];
@@ -65,7 +71,49 @@ static size_t contentbuf_size;
 static uint8_t *contentbuf, *slotbuf;
 static int bct_updated;
 static tegra_soctype_t soctype = TEGRA_SOCTYPE_INVALID;
+static bool spiboot_platform;
+static unsigned long bootdev_size;
 
+/*
+ * For tegra210 platforms, these are the names of partitions
+ * to be updated, **in order**.  Note that only the eMMC-based
+ * tegra210 platforms have redundant copies of most of the boot
+ * partitions, and that the naming of the redundant NVC partition
+ * is different between eMMC and SPIflash platforms.
+ */
+static const char *t210_emmc_partnames[] = {
+	"VER_b", "BCT", "NVC-1",
+	"PT-1", "TBC-1", "RP1-1", "EBT-1", "WB0-1", "BPF-1", "DTB-1", "TOS-1", "EKS-1", "LNX-1",
+	"BCT",
+	"BCT",
+	"PT", "TBC", "RP1", "EBT", "WB0", "BPF", "DTB", "TOS", "EKS", "LNX",
+	"NVC", "VER",
+};
+static const char *t210_spi_sd_partnames[] = {
+	"VER_b", "BCT", "NVC_R",
+	"BCT",
+	"BCT",
+	"PT", "TBC", "RP1", "EBT", "WB0", "BPF", "DTB", "TOS", "EKS", "LNX",
+	"NVC", "VER",
+};
+static const struct update_list_s update_list_t210_emmc = {
+	.count = sizeof(t210_emmc_partnames)/sizeof(t210_emmc_partnames[0]),
+	.partnames = t210_emmc_partnames,
+};
+static const struct update_list_s update_list_t210_spi_sd = {
+	.count = sizeof(t210_spi_sd_partnames)/sizeof(t210_spi_sd_partnames[0]),
+	.partnames = t210_spi_sd_partnames,
+};
+
+
+/*
+ * print_usage
+ *
+ * Does what it says, extracting option strings and
+ * help from the arrays defined above.
+ *
+ * Returns: nothing
+ */
 static void
 print_usage (void)
 {
@@ -87,6 +135,15 @@ print_usage (void)
 
 /*
  * set_bootdev_writeable_status
+ *
+ * Toggles the read-only soft switch in sysfs for eMMC boot0/boot1
+ * devices, if present.
+ *
+ * bootdev: device name
+ * make_writeable: 1 for writeable, 0 to disable writes
+ *
+ * Returns: 1 if device status changed, 0 if not.
+ *
  */
 static int
 set_bootdev_writeable_status (const char *bootdev, int make_writeable)
@@ -126,10 +183,98 @@ set_bootdev_writeable_status (const char *bootdev, int make_writeable)
 } /* set_bootdev_writeable_status */
 
 /*
+ * read_completely_at
+ *
+ * Utility function for seeking to a specific offset
+ * and reading a fixed number of bytes into a buffer,
+ * handling short reads.
+ *
+ * fd: file descriptor
+ * buf: pointer to read buffer
+ * bufsiz: number of bytes to read
+ * offset: offset from start of file/device
+ *
+ * Returns: number of bytes read, or
+ *          -1 on error (errno set)
+ *
+ */
+static ssize_t
+read_completely_at (int fd, void *buf, size_t bufsiz, off_t offset)
+{
+	ssize_t n, remain, total;
+	if (lseek(fd, offset, SEEK_SET) == (off_t) -1)
+		return -1;
+	for (remain = bufsiz, total = 0; remain > 0; total += n, remain -= n) {
+		n = read(fd, (uint8_t *) buf + total, remain);
+		if (n <= 0)
+			return -1;
+	}
+	return total;
+
+} /* read_completely_at */
+
+/*
+ * write_completely_at
+ *
+ * Utility function for seeking to a specific offset
+ * and writing a fixed number of bytes to a file or device,
+ * handling short writes.
+ *
+ * fd: file descriptor
+ * buf: pointer to data to be written
+ * bufsiz: number of bytes to write
+ * offset: offset from start of file/device
+ *
+ * Returns: number of bytes written, or
+ *          -1 on error (errno set)
+ *
+ */
+static ssize_t
+write_completely_at (int fd, void *buf, size_t bufsiz, off_t offset)
+{
+	ssize_t n, remain, total;
+	if (lseek(fd, offset, SEEK_SET) == (off_t) -1)
+		return -1;
+	for (remain = bufsiz, total = 0; remain > 0; total += n, remain -= n) {
+		n = write(fd, (uint8_t *) buf + total, remain);
+		if (n <= 0)
+			return -1;
+	}
+	return total;
+
+} /* write_completely_at */
+
+/*
+ * redundant_part_format
+ *
+ * Returns a printf-style format string for formatting
+ * the name of a redundant partition, handling the differences
+ * in naming conventions between different platform variants.
+ *
+ * partname: base name of partition
+ *
+ * Returns: character string pointer
+ *
+ */
+static const char *redundant_part_format(const char *partname)
+{
+	if (soctype != TEGRA_SOCTYPE_210)
+		return "%s_b";
+	if (strcmp(partname, "NVC") == 0)
+		return (spiboot_platform ? "%s_R" : "%s-1");
+	if (strcmp(partname, "VER") == 0)
+		return "%s_b";
+	return "%s-1";
+
+} /* redundant_part_format */
+
+/*
  * update_bct
  *
  * Special handling for writing the BCT. Content to be
  * written expected to be present in contentbuf.
+ *
+ * For tegra186/tegra194 platforms only.
  *
  * A BCT slot is 0xE00 = 3584 bytes.
  * A block is 16KiB and holds multiple slots.
@@ -140,15 +285,25 @@ set_bootdev_writeable_status (const char *bootdev, int make_writeable)
  * Write sequence is block 0/slot 1, then block 1/slot 0,
  * then block 0/slot 0.
  *
+ * bootfd: file descriptor for boot device
+ * curbct: pointer to buffer holding current BCT, previously read
+ * ent:    pointer to entry from the update payload
+ *
+ * returns: 0 on success, -1 on error (errno not set)
+ *
  */
 static int
 update_bct (int bootfd, void *curbct, struct update_entry_s *ent)
 {
-	ssize_t n, total, remain;
 	unsigned int block_size = 16384;
 	unsigned int page_size = 512;
 	int i;
 
+	if (soctype == TEGRA_SOCTYPE_210) {
+		printf("[INTERNAL ERROR]\n");
+		fprintf(stderr, "Internal error: incorrect BCT update function for t210\n");
+		return -1;
+	}
 	if ((soctype == TEGRA_SOCTYPE_186 && !bct_update_valid_t18x(slotbuf, curbct, &block_size, &page_size)) ||
 	    (soctype == TEGRA_SOCTYPE_194 && !bct_update_valid_t19x(slotbuf, curbct, &block_size, &page_size))) {
 		printf("[FAIL]\n");
@@ -169,21 +324,17 @@ update_bct (int bootfd, void *curbct, struct update_entry_s *ent)
 				offset = 0;
 				break;
 		}
-		printf("[offset=%lu]...", (unsigned long) offset);
-		if (lseek(bootfd, ent->part->first_lba * 512 + offset, SEEK_SET) == (off_t) -1) {
-			printf("[FAIL]\n");
-			perror("BCT");
-			return -1;
-		}
-
-		for (remain = ent->length, total = 0; remain > 0; total += n, remain -= n) {
-			n = write(bootfd, contentbuf + total, remain);
-			if (n <= 0) {
+		if (memcmp(contentbuf, slotbuf + offset, ent->length) == 0)
+			printf("[offset=%lu,no update needed]...", (unsigned long) offset);
+		else {
+			printf("[offset=%lu]...", (unsigned long) offset);
+			if (write_completely_at(bootfd, contentbuf, ent->length, ent->part->first_lba * 512 + offset) < 0)  {
 				printf("[FAIL]\n");
-				perror("writing BCT");
+				perror("BCT");
 				return -1;
 			}
 		}
+
 	}
 
 	fsync(bootfd);
@@ -194,60 +345,191 @@ update_bct (int bootfd, void *curbct, struct update_entry_s *ent)
 } /* update_bct */
 
 /*
+ * update_bct_t210
+ *
+ * Handles BCT updates to t210 platforms.
+ *
+ * On t210, there are up to 64 copies of the BCT.  Ordering is:
+ *  Last entry, (other updates), middle entries, (other updates), first entry
+ *
+ * SPI flash platforms put two copies at block 0; MMC platforms put one.
+ * All other entries start at beginning of a block.
+ *
+ * The 'which' argument is:
+ *   < 0 -> update last BCT entry
+ *   = 0 -> update first BCT entry
+ *  other -> update middle entries (number varies by platform)
+ *
+ * Caller must initialize 'which' to -1 before the first call, since
+ * the last BCT is always updated first.  This function will update
+ * it with each call.
+ *
+ * Note that we use 0-based counts for the redundant partitions
+ * (BCT, BCT-1, BCT-2, ... BCT-63), as opposed to 1-based counts
+ * (BCT, BCT-2, BCT-3, ... BCT-64) used in the update script provided
+ * in the L4T BSP.
+ *
+ * bootfd: file descriptor for boot device
+ * curbct: pointer to buffer holding current BCT, previously read
+ * ent:    pointer to entry from the update payload
+ * which:  pointer to BCT update context, see above
+ *
+ * returns: 0 on success, -1 on error (errno not set)
+ */
+static int
+update_bct_t210 (int bootfd, void *curbct, struct update_entry_s *ent, int *which)
+{
+	unsigned int block_size = 16384;
+	unsigned int page_size = 512;
+	unsigned int bctcopies = (spiboot_platform ? 2 : 1);
+	unsigned int bctpartsize;
+	int bctcount, bctstart, bctend, bctidx;
+	char bctname[32];
+
+	if (soctype != TEGRA_SOCTYPE_210) {
+		printf("[INTERNAL ERROR]\n");
+		fprintf(stderr, "Internal error: incorrect BCT function for non-t210\n");
+		return -1;
+	}
+	if (which == NULL) {
+		printf("[INTERNAL ERROR]\n");
+		fprintf(stderr, "Internal error: no BCT selection context for t210 update\n");
+		return -1;
+	}
+	if (!bct_update_valid_t21x(slotbuf, curbct, &block_size, &page_size)) {
+		printf("[FAIL]\n");
+		fprintf(stderr, "Error: validation check failed for BCT update\n");
+		return -1;
+	}
+	if (ent->length % page_size != 0) {
+		printf("[FAIL]\n");
+		fprintf(stderr, "Error: BCT update payload not an even multiple of boot device page size\n");
+		return -1;
+	}
+	if (ent->length * bctcopies > block_size) {
+		printf("[FAIL]\n");
+		fprintf(stderr, "Error: %u BCT payload%s too large for boot device block size\n",
+			bctcopies, (bctcopies == 1 ? "" : "s"));
+		return -1;
+	}
+	bctpartsize = (ent->part->last_lba - ent->part->first_lba + 1) * 512;
+	bctcount =  bctpartsize / block_size;
+	if (bctcount > 64)
+		bctcount = 64;
+
+	if (*which < 0) {
+		bctstart = bctend = bctcount - 1;
+		/* Write middle entries next */
+		*which = 1;
+	} else if (*which == 0) {
+		bctstart = bctend = 0;
+		/* End of the line, just reset back to last */
+		*which = -1;
+	} else {
+		bctstart = bctcount - 2;
+		bctend = 1;
+		/* Write first BCT next */
+		*which = 0;
+	}
+	for (bctidx = bctstart; bctidx >= bctend; bctidx -= 1) {
+		off_t offset = bctidx * block_size;
+		if (bctidx == 0)
+			strcpy(bctname, "BCT");
+		else
+			sprintf(bctname, "BCT-%u", bctidx);
+
+		if (memcmp(contentbuf, slotbuf + offset, ent->length) == 0) {
+			printf("[%s@%lu,no update needed]...", bctname, (unsigned long) offset);
+			fflush(stdout);
+			continue;
+		}
+
+		printf("[%s@%lu]...", bctname, (unsigned long) offset);
+		fflush(stdout);
+		if (write_completely_at(bootfd, contentbuf, ent->length, ent->part->first_lba * 512 + offset) < 0) {
+			printf("[FAIL]\n");
+			perror("BCT");
+			return -1;
+		}
+		if (bctidx == 0 && bctcopies == 2) {
+			offset += ent->length;
+			if (write_completely_at(bootfd, contentbuf, ent->length, ent->part->first_lba * 512 + offset) < 0) {
+				printf("[FAIL]\n");
+				perror("BCT");
+				return -1;
+			}
+		}
+	}
+	fsync(bootfd);
+	bct_updated = 1;
+	printf("[OK]\n");
+	return 0;
+
+} /* update_bct_t210 */
+
+/*
  * maybe_update_bootpart
  *
  * Update a boot partition if its current contents
  * differ from the BUP content (which is in contentbuf).
  *
+ * On systems that boot from eMMC, boot partitions may be
+ * located either in /dev/mmcblk0boot0 (called the "boot device")
+ * or /dev/mmcblk0boot1 (called the "GPT device").
+ *
+ * bootfd: file descriptor for boot device
+ * gptfd:  file descriptor for second boot (aka "GPT") device
+ * ent: pointer to entry from update payload
+ * is_bct: 1 if this is a BCT update, 0 otherwise
+ * bctctx: 'which' context for BCT updates (for t210 platforms)
+ *
+ * Returns: 0 on success, -1 on error (errno not set)
+ *
  */
 static int
-maybe_update_bootpart (int bootfd, struct update_entry_s *ent, int is_bct)
+maybe_update_bootpart (int bootfd, int gptfd, struct update_entry_s *ent, int is_bct, int *bctctx)
 {
-	ssize_t n, total, remain;
+	int fd;
+	off_t offset;
 
 	if (ent->length > (ent->part->last_lba - ent->part->first_lba + 1) * 512) {
 		printf("[FAIL]\n");
 		fprintf(stderr, "Error: BUP contents too large for boot partition\n");
 		return -1;
 	}
-
-	if (lseek(bootfd, ent->part->first_lba * 512, SEEK_SET) == (off_t) -1) {
+	fd = bootfd;
+	offset = ent->part->first_lba * 512;
+	if (offset >= bootdev_size) {
+		if (gptfd < 0) {
+			printf("[FAIL]\n");
+			fprintf(stderr, "Partition %s starts past end of boot device\n", ent->partname);
+			return -1;
+		}
+		fd = gptfd;
+		offset -= bootdev_size;
+	}
+	if (read_completely_at(fd, slotbuf, ent->length, offset) < 0) {
 		printf("[FAIL]\n");
 		perror(ent->partname);
 		return -1;
 	}
-	for (remain = ent->length, total = 0; remain > 0; total += n, remain -= n) {
-		n = read(bootfd, slotbuf + total, remain);
-		if (n <= 0) {
-			printf("[FAIL]\n");
-			perror("reading BCT");
-			return -1;
-		}
-	}
+	if (is_bct)
+		return (soctype == TEGRA_SOCTYPE_210
+			? update_bct_t210(bootfd, contentbuf, ent, bctctx)
+			: update_bct(bootfd, contentbuf, ent));
+
 	if (memcmp(contentbuf, slotbuf, ent->length) == 0) {
 		printf("[no update needed]\n");
 		return 0;
 	}
 
-	if (is_bct)
-		return update_bct(bootfd, contentbuf, ent);
-
-	if (lseek(bootfd, ent->part->first_lba * 512, SEEK_SET) == (off_t) -1) {
+	if (write_completely_at(fd, contentbuf, ent->length, offset) < 0) {
 		printf("[FAIL]\n");
 		perror(ent->partname);
 		return -1;
 	}
 
-	for (remain = ent->length, total = 0; remain > 0; total += n, remain -= n) {
-		n = write(bootfd, contentbuf + total, remain);
-		if (n <= 0) {
-			printf("[FAIL]\n");
-			perror(ent->partname);
-			return -1;
-		}
-	}
-
-	fsync(bootfd);
+	fsync(fd);
 	printf("[OK]\n");
 	return 0;
 
@@ -255,11 +537,23 @@ maybe_update_bootpart (int bootfd, struct update_entry_s *ent, int is_bct)
 
 /*
  * process_entry
+ *
+ * Processes an entry from the update payload.
+ *
+ * bupctx: context pointer for the open BUP payload
+ * bootfd: file descriptor for the boot device
+ * gptfd:  file descriptor for the "GPT" device
+ * ent:    pointer to update payload entry to process
+ * dryrun: non-zero for a dry run (no writes)
+ * bctctx: pointer to 'which' contenxt for t210 BCT updates
+ *
+ * Returns: 0 on success, -1 on error (errno not set)
+ *
  */
 static int
-process_entry (bup_context_t *bupctx, int bootfd, struct update_entry_s *ent, int dryrun)
+process_entry (bup_context_t *bupctx, int bootfd, int gptfd, struct update_entry_s *ent, int dryrun, int *bctctx)
 {
-	ssize_t n, total, remain;
+	ssize_t total, n;
 	int fd;
 
 	printf("  Processing %s... ", ent->partname);
@@ -283,22 +577,29 @@ process_entry (bup_context_t *bupctx, int bootfd, struct update_entry_s *ent, in
 		return 0;
 	}
 	if (ent->part != NULL)
-		return maybe_update_bootpart(bootfd, ent, strcmp(ent->partname, "BCT") == 0);
+		return maybe_update_bootpart(bootfd, gptfd, ent, strcmp(ent->partname, "BCT") == 0, bctctx);
 
-	fd = open(ent->devname, O_WRONLY);
+	fd = open(ent->devname, O_RDWR);
 	if (fd < 0) {
 		printf("[FAIL]\n");
 		perror(ent->devname);
 		return -1;
 	}
-	for (remain = ent->length, total = 0; remain > 0; total += n, remain -= n) {
-		n = write(fd, contentbuf + total, remain);
-		if (n <= 0) {
-			printf("[FAIL]\n");
-			perror(ent->partname);
-			close(fd);
-			return -1;
-		}
+	if (read_completely_at(fd, slotbuf, ent->length, 0) < 0) {
+		printf("[FAIL]\n");
+		perror(ent->devname);
+		return -1;
+	}
+	if (memcmp(contentbuf, slotbuf, ent->length) == 0) {
+		printf("[no update needed]\n");
+		close(fd);
+		return 0;
+	}
+	if (write_completely_at(fd, contentbuf, ent->length, 0) < 0) {
+		printf("[FAIL]\n");
+		perror(ent->devname);
+		close(fd);
+		return -1;
 	}
 
 	fsync(fd);
@@ -311,13 +612,21 @@ process_entry (bup_context_t *bupctx, int bootfd, struct update_entry_s *ent, in
 /*
  * order_entries
  *
- * Sort an entries list to ensure that we process
- * mb2/mb2_b before BCT before mb1/mb1_b.
+ * Sorts an entries list to ensure that we process
+ * mb2/mb2_b before BCT before mb1/mb1_b.  For
+ * tegra186/tegra194 platforms only.
+ *
+ * orig: array of payload entries to process
+ * ordered: array of pointers to be filled by this function
+ * count: length of the arrays
+ *
+ * Returns: nothing
  */
 static void
-order_entries (struct update_entry_s *orig, struct update_entry_s **ordered, int count)
+order_entries (struct update_entry_s *orig, struct update_entry_s **ordered, unsigned int count)
 {
-	int i, j, mb1, mb1_b, bct, mb2, mb2_b;
+	int mb1, mb1_b, bct, mb2, mb2_b;
+	unsigned int i, j;
 
 	mb1 = mb1_b = bct = mb2 = mb2_b = -1;
 	j = 0;
@@ -353,13 +662,90 @@ order_entries (struct update_entry_s *orig, struct update_entry_s **ordered, int
 } /* order_entries */
 
 /*
+ * find_entry_by_name
+ *
+ * Returns a pointer to the update entry for a named partition.
+ *
+ * list: array of update entries
+ * count: size of the array
+ * name: name to locate in the array
+ *
+ * Returns: NULL on error, valid pointer otherwise
+ */
+static struct update_entry_s *
+find_entry_by_name (struct update_entry_s *list, unsigned int count, const char *name)
+{
+	unsigned int i;
+	for (i = 0; i < count; i += 1)
+		if (strcmp(list[i].partname, name) == 0)
+			return &list[i];
+	return NULL;
+
+} /* find_entry_by_name */
+
+/*
+ * order_entries_t210
+ *
+ * Builds an array of pointers to update entries for
+ * performing partition updates in the correct order
+ * on tegra210 systems.
+ *
+ * Note that on tegra210s (unliked tegra186/tegra194), the
+ * ordered list will be longer than the original list, since
+ * BCT updates are handled in multiple parts (last, middle, first),
+ * with each update pointing back to the same original entry.
+ *
+ * Entries that do not appear in the fixed-order list are
+ * appended to the end.
+ *
+ * orig: array of payload entries to process
+ * ordered: array of pointers to be filled by this function
+ * count: length of the arrays
+ *
+ * Returns: number of entries in the ordered list
+ */
+static unsigned int
+order_entries_t210 (struct update_entry_s *orig, struct update_entry_s **ordered, unsigned int count)
+{
+	const struct update_list_s *update_list = (spiboot_platform
+						   ? &update_list_t210_spi_sd
+						   : &update_list_t210_emmc);
+	struct update_entry_s *ent;
+	unsigned int i, retcount;
+	bool used[128];
+
+	if (count > sizeof(used)/sizeof(used[0])) {
+		fprintf(stderr, "Internal error: update entry list too long\n");
+		return 0;
+	}
+	memset(used, 0, sizeof(used));
+	for (i = 0; i < update_list->count; i++) {
+		ent = find_entry_by_name(orig, count, update_list->partnames[i]);
+		if (ent == NULL) {
+			fprintf(stderr, "Error: payload or partition not found for %s\n",
+				update_list->partnames[i]);
+			return 0;
+		}
+		ordered[i] = ent;
+		used[ent-orig] = true;
+	}
+	retcount = update_list->count;
+	for (i = 0; i < count; i++) {
+		if (!used[i])
+			ordered[retcount++] = &orig[i];
+	}
+	return retcount;
+
+} /* order_entries_t210 */
+
+/*
  * main program
  */
 int
 main (int argc, char * const argv[])
 {
-	int c, which, fd;
-	int reset_bootdev;
+	int c, which, fd, gptfd, err;
+	int reset_bootdev, reset_gptdev;
 	gpt_context_t *gptctx;
 	bup_context_t *bupctx;
 	smd_context_t *smdctx = NULL;
@@ -367,6 +753,7 @@ main (int argc, char * const argv[])
 	void *bupiter;
 	const char *partname;
 	const char *suffix = NULL;
+	const char *bootdev;
 	off_t offset;
 	size_t length;
 	size_t largest_length;
@@ -374,13 +761,14 @@ main (int argc, char * const argv[])
 	char pathname[PATH_MAX];
 	int initialize = 0;
 	int dryrun = 0;
-	int ret = 0;
+	int ret = 1;
 	int missing_count;
 	int curslot = -1;
 	int slot_specified = 0;
 	const char *missing[32];
 	struct update_entry_s *ordered_entries[MAX_ENTRIES], mb1_other;
 	unsigned int i;
+	off_t bootdev_end_offset;
 
 	while ((c = getopt_long_only(argc, argv, shortopts, options, &which)) != -1) {
 		switch (c) {
@@ -442,27 +830,46 @@ main (int argc, char * const argv[])
 		}
 	}
 
-	if (soctype != TEGRA_SOCTYPE_186 &&
-	    soctype != TEGRA_SOCTYPE_194) {
-		fprintf(stderr, "Error: unsupported SoC type: %s\n", cvm_soctype_name(soctype));
-		return 1;
-	}
-
-	if (!slot_specified && !initialize) {
-		curslot = smd_get_current_slot();
-		if (curslot < 0) {
-			perror("retrieving current boot slot");
+	if (soctype == TEGRA_SOCTYPE_186 ||
+	    soctype == TEGRA_SOCTYPE_194) {
+		if (!slot_specified && !initialize) {
+			curslot = smd_get_current_slot();
+			if (curslot < 0) {
+				perror("retrieving current boot slot");
+				return 1;
+			}
+			if (curslot == 0)
+				suffix = "_b";
+			else
+				suffix = "";
+		}
+	} else {
+		if (slot_specified) {
+			fprintf(stderr, "Error: unsupported operation for t210 platform\n");
 			return 1;
 		}
-		if (curslot == 0)
-			suffix = "_b";
-		else
-			suffix = "";
+		// on t210, the operation is always 'initialize'
+		initialize = 1;
 	}
 
 	bupctx = bup_init(argv[optind]);
 	if (bupctx == NULL) {
 		perror(argv[optind]);
+		return 1;
+	}
+
+	bootdev = bup_boot_device(bupctx);
+	if (strlen(bootdev) < 8) {
+		fprintf(stderr, "Error: unrecognized boot device: %s\n", bootdev);
+		bup_finish(bupctx);
+		return 1;
+	}
+
+	if (memcmp(bootdev, "/dev/mtd", 8) == 0)
+		spiboot_platform = true;
+	else if (memcmp(bootdev, "/dev/mmc", 8) != 0) {
+		fprintf(stderr, "Error: unrecognized boot device: %s\n", bootdev);
+		bup_finish(bupctx);
 		return 1;
 	}
 
@@ -472,43 +879,73 @@ main (int argc, char * const argv[])
 		bup_finish(bupctx);
 		return 1;
 	}
-	if (gpt_load(gptctx, GPT_LOAD_BACKUP_ONLY|GPT_NVIDIA_SPECIAL)) {
+
+	if (soctype == TEGRA_SOCTYPE_210)
+		err = gpt_load_from_config(gptctx);
+	else
+		err = gpt_load(gptctx, GPT_LOAD_BACKUP_ONLY|GPT_NVIDIA_SPECIAL);
+
+	if (err != 0) {
 		fprintf(stderr, "Error: cannot load boot sector partition table\n");
 		gpt_finish(gptctx);
 		bup_finish(bupctx);
 		return 1;
 	}
 
+	if (spiboot_platform || dryrun) {
+		reset_gptdev = 0;
+		gptfd = -1;
+	} else {
+		reset_gptdev = set_bootdev_writeable_status(bup_gpt_device(bupctx), 1);
+		gptfd = open(bup_gpt_device(bupctx), O_RDWR);
+		if (gptfd < 0) {
+			perror(bup_gpt_device(bupctx));
+			goto reset_and_depart;
+		}
+	}
+
 	if (dryrun) {
 		reset_bootdev = 0;
-		fd = open(bup_boot_device(bupctx), O_RDONLY);
+		fd = open(bootdev, O_RDONLY);
 	} else {
-		reset_bootdev = set_bootdev_writeable_status(bup_boot_device(bupctx), 1);
-		fd = open(bup_boot_device(bupctx), O_RDWR);
+		reset_bootdev = set_bootdev_writeable_status(bootdev, 1);
+		fd = open(bootdev, O_RDWR);
 	}
 	if (fd < 0) {
-		perror(bup_boot_device(bupctx));
+		perror(bootdev);
 		goto reset_and_depart;
 	}
-
-	smdctx = smd_init(gptctx, fd);
-	if (smdctx == NULL) {
-		if (initialize) {
-			smdctx = smd_new(REDUNDANCY_FULL);
-			if (smdctx == NULL)
-				perror("initializing slot metadata");
-		} else
-			perror("loading slot metadata");
-		if (smdctx == NULL)
-			goto reset_and_depart;
+	bootdev_end_offset = lseek(fd, 0, SEEK_END);
+	if (bootdev_end_offset == (off_t) -1) {
+		perror(bootdev);
+		goto reset_and_depart;
 	}
+	bootdev_size = (unsigned long) bootdev_end_offset;
+	lseek(fd, 0, SEEK_SET);
 
-	if (!slot_specified && smd_redundancy_level(smdctx) != REDUNDANCY_FULL) {
-		if (dryrun)
-			printf("[skip] enable redundancy in slot metadata\n");
-		else if (smd_set_redundancy_level(smdctx, REDUNDANCY_FULL) < 0) {
-			perror("enabling redundancy in slot metadata");
-			goto reset_and_depart;
+	if (soctype == TEGRA_SOCTYPE_210)
+		smdctx = NULL;
+	else {
+		smdctx = smd_init(gptctx, fd);
+		if (smdctx == NULL) {
+			if (initialize) {
+				smdctx = smd_new(REDUNDANCY_FULL);
+				if (smdctx == NULL)
+					perror("initializing slot metadata");
+			} else
+				perror("loading slot metadata");
+			if (smdctx == NULL) {
+				goto reset_and_depart;
+			}
+		}
+
+		if (!slot_specified && smd_redundancy_level(smdctx) != REDUNDANCY_FULL) {
+			if (dryrun)
+				printf("[skip] enable redundancy in slot metadata\n");
+			else if (smd_set_redundancy_level(smdctx, REDUNDANCY_FULL) < 0) {
+				perror("enabling redundancy in slot metadata");
+				goto reset_and_depart;
+			}
 		}
 	}
 
@@ -533,9 +970,11 @@ main (int argc, char * const argv[])
 	 * For initialization, we separate the redundant entries from the non-redundant
 	 * ones and write the non-redundant entries last. While the BCT appears to
 	 * be non-redundant (only one BCT partition), it is internally redundant and
-	 * requires special handling.
+	 * requires special handling (which is different for tegra186/194 vs tegra210).
 	 *
-	 * For updates, we never write the non-redundant entries.
+	 * For updates on tegra186/194 platforms, we never write the non-redundant entries.
+	 * For tegra210 platforms, `initialize` is always set, since those platforms are
+	 * not A/B redundant.
 	 */
 	bupiter = 0;
 	redundant_entry_count = nonredundant_entry_count = 0;
@@ -545,7 +984,7 @@ main (int argc, char * const argv[])
 		gpt_entry_t *part, *part_b;
 		char partname_b[64], pathname_b[PATH_MAX];
 
-		sprintf(partname_b, "%s_b", partname);
+		sprintf(partname_b, redundant_part_format(partname), partname);
 		memset(&updent, 0, sizeof(updent));
 		strcpy(updent.partname, partname);
 		updent.bup_offset = offset;
@@ -555,12 +994,14 @@ main (int argc, char * const argv[])
 
 		part = gpt_find_by_name(gptctx, partname);
 		if (part != NULL) {
+			/*
+			 * Partition is located in the boot device
+			 */
 			part_b = gpt_find_by_name(gptctx, partname_b);
 			if (initialize) {
 				if (part_b != NULL || strcmp(partname, "BCT") == 0) {
 					if (redundant_entry_count >= sizeof(redundant_entries)/sizeof(redundant_entries[0])) {
 						fprintf(stderr, "too many partitions to initialize\n");
-						ret = 1;
 						goto reset_and_depart;
 					}
 					redundant_entries[redundant_entry_count] = updent;
@@ -575,7 +1016,6 @@ main (int argc, char * const argv[])
 				} else {
 					if (nonredundant_entry_count >= sizeof(nonredundant_entries)/sizeof(nonredundant_entries[0])) {
 						fprintf(stderr, "too many (non-redundant) partitions to initialize\n");
-						ret = 1;
 						goto reset_and_depart;
 					}
 					nonredundant_entries[nonredundant_entry_count] = updent;
@@ -585,7 +1025,6 @@ main (int argc, char * const argv[])
 			} else if (part_b != NULL || strcmp(partname, "BCT") == 0) {
 				if (redundant_entry_count >= sizeof(redundant_entries)/sizeof(redundant_entries[0])) {
 					fprintf(stderr, "too many partitions to update\n");
-					ret = 1;
 					goto reset_and_depart;
 				}
 				redundant_entries[redundant_entry_count] = updent;
@@ -604,14 +1043,17 @@ main (int argc, char * const argv[])
 				redundant_entry_count += 1;
 			}
 		} else {
+			/*
+			 * Normal partition, not in the boot device
+			 */
 			int redundant;
 			sprintf(pathname, "/dev/disk/by-partlabel/%s", partname);
 			if (access(pathname, F_OK|W_OK) != 0) {
 				fprintf(stderr, "Error: cannot locate partition: %s\n", partname);
-				ret = 1;
 				goto reset_and_depart;
 			}
-			sprintf(pathname_b, "/dev/disk/by-partlabel/%s_b", partname);
+			strcpy(pathname_b, "/dev/disk/by-partlabel/");
+			sprintf(pathname_b + strlen(pathname_b), redundant_part_format(partname), partname);
 			redundant = access(pathname_b, F_OK|W_OK) == 0;
 			if (initialize) {
 				if (redundant) {
@@ -636,6 +1078,20 @@ main (int argc, char * const argv[])
 		}
 	}
 
+	/*
+	 * For tegra210, just lump all entries into the 'redundant' list.
+	 */
+	if (soctype == TEGRA_SOCTYPE_210) {
+		unsigned int ent;
+		if (redundant_entry_count + nonredundant_entry_count > MAX_ENTRIES) {
+			fprintf(stderr, "Error: too many partitions to initialize\n");
+			goto reset_and_depart;
+		}
+		for (ent = 0; ent < nonredundant_entry_count; ent += 1)
+			redundant_entries[redundant_entry_count++] = nonredundant_entries[ent];
+		nonredundant_entry_count = 0;
+	}
+
 	contentbuf = malloc(largest_length);
 	slotbuf = malloc(largest_length);
 	if (contentbuf == NULL || slotbuf == NULL) {
@@ -644,40 +1100,55 @@ main (int argc, char * const argv[])
 	}
 	contentbuf_size = largest_length;
 
-	order_entries(redundant_entries, ordered_entries, redundant_entry_count);
-
-	for (i = 0; i < redundant_entry_count; i++)
-		if (process_entry(bupctx, fd, ordered_entries[i], dryrun) != 0)
+	if (soctype == TEGRA_SOCTYPE_210) {
+		int bctctx = -1;
+		redundant_entry_count = order_entries_t210(redundant_entries, ordered_entries, redundant_entry_count);
+		if (redundant_entry_count == 0)
 			goto reset_and_depart;
-
-	if (initialize) {
-		for (i = 0; i < nonredundant_entry_count; i++)
-			if (process_entry(bupctx, fd, &nonredundant_entries[i], dryrun) != 0)
+		for (i = 0; i < redundant_entry_count; i++)
+			if (process_entry(bupctx, fd, gptfd, ordered_entries[i], dryrun, &bctctx) != 0)
 				goto reset_and_depart;
-	} else if (bct_updated) {
-		/*
-		 * If the BCT was updated, we must update both mb1 and mb1_b
-		 */
-		if (mb1_other.partname[0] == '\0') {
-			fprintf(stderr, "Error: could not update alternate mb1 partition\n");
-			goto reset_and_depart;
+	} else {
+		order_entries(redundant_entries, ordered_entries, redundant_entry_count);
+
+		for (i = 0; i < redundant_entry_count; i++)
+			if (process_entry(bupctx, fd, gptfd, ordered_entries[i], dryrun, NULL) != 0)
+				goto reset_and_depart;
+
+		if (initialize) {
+			for (i = 0; i < nonredundant_entry_count; i++)
+				if (process_entry(bupctx, fd, gptfd, &nonredundant_entries[i], dryrun, NULL) != 0)
+					goto reset_and_depart;
+		} else if (bct_updated) {
+			/*
+			 * If the BCT was updated, we must update both mb1 and mb1_b
+			 */
+			if (mb1_other.partname[0] == '\0') {
+				fprintf(stderr, "Error: could not update alternate mb1 partition\n");
+				goto reset_and_depart;
+			}
+			if (process_entry(bupctx, fd, gptfd, &mb1_other, dryrun, NULL) != 0)
+				goto reset_and_depart;
 		}
-		if (process_entry(bupctx, fd, &mb1_other, dryrun) != 0)
-			goto reset_and_depart;
-	}
-	if (dryrun) {
-		if (!slot_specified)
-			printf("[skip] mark slot %d as active\n", (initialize ? 0 : 1 - curslot));
-	} else if (!slot_specified) {
-		unsigned int newslot = (initialize ? 0 : 1 - curslot);
-		if (smd_slot_mark_active(smdctx, newslot) < 0) {
-			perror("marking new boot slot active");
-			goto reset_and_depart;
+		if (dryrun) {
+			if (!slot_specified)
+				printf("[skip] mark slot %d as active\n", (initialize ? 0 : 1 - curslot));
+		} else if (!slot_specified) {
+			unsigned int newslot = (initialize ? 0 : 1 - curslot);
+			if (smd_slot_mark_active(smdctx, newslot) < 0) {
+				perror("marking new boot slot active");
+				goto reset_and_depart;
+			}
+			printf("Slot %u marked as active for next boot\n", newslot);
+			if (smd_update(smdctx, gptctx, fd, initialize) < 0)
+				perror("updating slot metadata");
 		}
-		printf("Slot %u marked as active for next boot\n", newslot);
-		if (smd_update(smdctx, gptctx, fd, initialize) < 0)
-			perror("updating slot metadata");
 	}
+
+	/*
+	 * Success if we get through all of the above
+	 */
+	ret = 0;
 
   reset_and_depart:
 	if (smdctx)
@@ -687,8 +1158,14 @@ main (int argc, char * const argv[])
 			fsync(fd);
 		close(fd);
 	}
+	if (gptfd >= 0) {
+		fsync(gptfd);
+		close(gptfd);
+	}
 	if (reset_bootdev)
-		set_bootdev_writeable_status(bup_boot_device(bupctx), 0);
+		set_bootdev_writeable_status(bootdev, 0);
+	if (reset_gptdev)
+		set_bootdev_writeable_status(bup_gpt_device(bupctx), 0);
 	if (slotbuf)
 		free(slotbuf);
 	if (contentbuf)


### PR DESCRIPTION
* `tegra-bootloader-update` now support tegra210-based devices (TX1 and Nano)
* Fixed an issue with BCT updates on t186/t194 platforms with secure boot enabled
* Updated `tegra-bootinfo` to use more suitable locations for storing its data on t210 platforms.
* Changed the default data size for `tegra-bootinfo` from 1KiB to 8KiB.
* Added in some missing function header comments.
* Switched to using write-only-if-different for all partitions, not just boot device partitions.
* Added an erase step before writing.  This slows down updates (particularly for SPI flash), but is more in line with the NV-provided tools.
* Added emulation scripts for `nvbootctrl` and `nv_update_engine` to help with migration.