### PR TITLE
Fix updater dry runs on Nano-eMMC platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,17 +1,17 @@
 dnl
 dnl configure.ac - autoconf script for Tegra boot tools
 dnl
-dnl Copyright (c) 2019, 2020 Matthew Madison
+dnl Copyright (c) 2019-2021 Matthew Madison
 dnl
 
-AC_INIT([tegra-boot-tools], [2.2.0])
+AC_INIT([tegra-boot-tools], [2.2.1])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAJOR], [2], [Major version])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [2], [Minor version])
-AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [0], [Maintenance level])
+AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [1], [Maintenance level])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
 AC_COPYRIGHT([
-Copyright (c) 2019, 2020 Matthew Madison
+Copyright (c) 2019-2021 Matthew Madison
 ])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/tegra-bootloader-update.c
+++ b/tegra-bootloader-update.c
@@ -1036,7 +1036,7 @@ int
 main (int argc, char * const argv[])
 {
 	int c, which, fd = -1, gptfd, err;
-	int reset_bootdev = 0, reset_gptdev;
+	int reset_bootdev = 0, reset_gptdev = 0;
 	gpt_context_t *gptctx;
 	bup_context_t *bupctx;
 	smd_context_t *smdctx = NULL;
@@ -1186,12 +1186,15 @@ main (int argc, char * const argv[])
 		return 1;
 	}
 
-	if (spiboot_platform || dryrun) {
-		reset_gptdev = 0;
+	if (spiboot_platform)
 		gptfd = -1;
-	} else {
-		reset_gptdev = set_bootdev_writeable_status(bup_gpt_device(bupctx), 1);
-		gptfd = open(bup_gpt_device(bupctx), O_RDWR);
+	else {
+		if (dryrun)
+			gptfd = open(bup_gpt_device(bupctx), O_RDONLY);
+		else {
+			reset_gptdev = set_bootdev_writeable_status(bup_gpt_device(bupctx), 1);
+			gptfd = open(bup_gpt_device(bupctx), O_RDWR);
+		}
 		if (gptfd < 0) {
 			perror(bup_gpt_device(bupctx));
 			goto reset_and_depart;


### PR DESCRIPTION
With the addition of the version check logic, we do have to open the GPT device when doing an update dryrun.