### PR TITLE
T210 force initialize

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,10 @@ dnl
 dnl Copyright (c) 2019-2021 Matthew Madison
 dnl
 
-AC_INIT([tegra-boot-tools], [2.2.1])
+AC_INIT([tegra-boot-tools], [2.2.2])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAJOR], [2], [Major version])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [2], [Minor version])
-AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [1], [Maintenance level])
+AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [2], [Maintenance level])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
 AC_COPYRIGHT([


### PR DESCRIPTION
In `tegra-bootloader-update`, let the user override some of the pre-update safety checks on T210 platforms by explicitly specifying the `--initialize` option.