### PR TITLE
Update for L4T R32.5.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,10 @@ dnl
 dnl Copyright (c) 2019-2021 Matthew Madison
 dnl
 
-AC_INIT([tegra-boot-tools], [2.2.2])
+AC_INIT([tegra-boot-tools], [2.2.3])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAJOR], [2], [Major version])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [2], [Minor version])
-AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [2], [Maintenance level])
+AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [3], [Maintenance level])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
 AC_COPYRIGHT([


### PR DESCRIPTION
NVIDIA upgraded the slot metadata block to a new version that supports some extensions.  The SMD code is updated to handle the new version and validate the extensions block, so the tools work with the new L4T.