### PR TITLE
Enhance full bootloader initialization in tegra-bootloader-update

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 # Tegra boot/update tools
 #
-# Copyright (c) 2019, 2020 Matthew Madison
+# Copyright (c) 2019-2021, Matthew Madison
 #
 
 AUTOMAKE_OPTIONS = subdir-objects foreign
@@ -24,7 +24,7 @@ do_subst = sed -e's,[@]bindir[@],$(bindir),g' \
                -e's,[@]BOOTDEVS[@],$(BOOTDEVS),g'
 
 lib_LTLIBRARIES = libtegra-boot-tools.la
-libtegra_boot_tools_la_SOURCES = smd.c smd.h gpt.c gpt.h bup.c bup.h ver.c ver.h posix-crc32.c posix-crc32.h
+libtegra_boot_tools_la_SOURCES = smd.c smd.h gpt.c gpt.h bup.c bup.h ver.c ver.h posix-crc32.c posix-crc32.h util.c util.h
 libtegra_boot_tools_la_CFLAGS = $(ZLIB_CFLAGS) $(UUID_CFLAGS) $(TEGRA_EEPROM_CFLAGS)
 libtegra_boot_tools_la_CPPFLAGS = -DCONFIGPATH="$(tbtdir)"
 libtegra_boot_tools_la_LIBADD = $(ZLIB_LIBS) $(UUID_LIBS) $(TEGRA_EEPROM_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,10 +25,10 @@ do_subst = sed -e's,[@]bindir[@],$(bindir),g' \
 
 lib_LTLIBRARIES = libtegra-boot-tools.la
 libtegra_boot_tools_la_SOURCES = smd.c smd.h gpt.c gpt.h bup.c bup.h ver.c ver.h posix-crc32.c posix-crc32.h
-libtegra_boot_tools_la_CFLAGS = $(ZLIB_CFLAGS) $(TEGRA_EEPROM_CFLAGS)
+libtegra_boot_tools_la_CFLAGS = $(ZLIB_CFLAGS) $(UUID_CFLAGS) $(TEGRA_EEPROM_CFLAGS)
 libtegra_boot_tools_la_CPPFLAGS = -DCONFIGPATH="$(tbtdir)"
-libtegra_boot_tools_la_LIBADD = $(ZLIB_LIBS) $(TEGRA_EEPROM_LIBS)
-libtegra_boot_tools_la_LDFLAGS = $(ZLIB_LDFLAGS) $(TEGRA_EEPROM_LDFLAGS)
+libtegra_boot_tools_la_LIBADD = $(ZLIB_LIBS) $(UUID_LIBS) $(TEGRA_EEPROM_LIBS)
+libtegra_boot_tools_la_LDFLAGS = $(ZLIB_LDFLAGS) $(UUID_LIBS) $(TEGRA_EEPROM_LDFLAGS)
 tbtinc_HEADERS = smd.h gpt.h bup.h
 pkgconfig_DATA = tegra-boot-tools.pc
 

--- a/bct.h
+++ b/bct.h
@@ -1,9 +1,9 @@
-#ifndef bct_h__
-#define bct_h__
+#ifndef bct_h_included
+#define bct_h_included
 /* Copyright (c) 2020 Matthew Madison */
 
 int bct_update_valid_t18x(void *cur_bct, void *cand_bct);
 int bct_update_valid_t19x(void *cur_bct, void *cand_bct);
 int bct_update_valid_t21x(void *cur_bct, void *cand_bct, unsigned int *block_size, unsigned int *page_size);
 
-#endif /* bct_h__ */
+#endif /* bct_h_included */

--- a/bup.h
+++ b/bup.h
@@ -3,6 +3,7 @@
 /* Copyright (c) 2019-2020, Matthew Madison */
 
 #include <sys/types.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
 
@@ -14,9 +15,9 @@ void bup_finish(bup_context_t *ctx);
 const char *bup_gpt_device(bup_context_t *ctx);
 const char *bup_boot_device(bup_context_t *ctx);
 const char *bup_tnspec(bup_context_t *ctx);
-int bup_enumerate_entries(bup_context_t *ctx, void **iterctx,
-                          const char **partname, off_t *offset,
-                          size_t *length, unsigned int *version);
+bool bup_enumerate_entries(bup_context_t *ctx, void **iterctx,
+			   const char **partname, off_t *offset,
+			   size_t *length, unsigned int *version);
 int bup_find_missing_entries(bup_context_t *ctx, const char **missing_parts,
 			     size_t max_missing);
 off_t bup_setpos(bup_context_t *ctx, off_t offset);

--- a/bup.h
+++ b/bup.h
@@ -1,5 +1,5 @@
-#ifndef bup_h__
-#define bup_h__
+#ifndef bup_h_included
+#define bup_h_included
 /* Copyright (c) 2019-2020, Matthew Madison */
 
 #include <sys/types.h>
@@ -23,4 +23,4 @@ int bup_find_missing_entries(bup_context_t *ctx, const char **missing_parts,
 off_t bup_setpos(bup_context_t *ctx, off_t offset);
 ssize_t bup_read (bup_context_t *ctx, void *buf, size_t bufsize);
 
-#endif /* bup_h__ */
+#endif /* bup_h_included */

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ AC_DEFINE_UNQUOTED([EXTENSION_SECTOR_COUNT], [$with_extended_sector_count], [Num
 
 PKG_PROG_PKG_CONFIG([0.29])
 PKG_CHECK_MODULES([ZLIB], [zlib])
+PKG_CHECK_MODULES([UUID], [uuid])
 PKG_CHECK_MODULES([TEGRA_EEPROM], [tegra-eeprom])
 
 AS_IF([test "x$with_systemdsystemunitdir" = "xcheck"],

--- a/configure.ac
+++ b/configure.ac
@@ -1,17 +1,17 @@
 dnl
 dnl configure.ac - autoconf script for Tegra boot tools
 dnl
-dnl Copyright (c) 2019-2021 Matthew Madison
+dnl Copyright (c) 2019-2021, Matthew Madison
 dnl
 
-AC_INIT([tegra-boot-tools], [2.2.4])
+AC_INIT([tegra-boot-tools], [2.3.0])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAJOR], [2], [Major version])
-AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [2], [Minor version])
-AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [4], [Maintenance level])
+AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [3], [Minor version])
+AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [0], [Maintenance level])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
 AC_COPYRIGHT([
-Copyright (c) 2019-2021 Matthew Madison
+Copyright (c) 2019-2021, Matthew Madison
 ])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/gpt.c
+++ b/gpt.c
@@ -65,8 +65,8 @@ struct gpt_context_s {
 	unsigned int blocksize;
 	off_t devsize;
 	void *buffer;
-	int is_mmcboot1;
-	int primary_valid, backup_valid;
+	bool is_mmcboot1;
+	bool primary_valid, backup_valid;
 	struct gpt_header_s primary_header;
 	struct gpt_header_s backup_header;
 	unsigned int entry_count;

--- a/gpt.h
+++ b/gpt.h
@@ -4,6 +4,8 @@
 
 #include <stdint.h>
 
+#define GPT_SIZE_IN_BLOCKS 32
+
 struct gpt_context_s;
 typedef struct gpt_context_s gpt_context_t;
 
@@ -17,15 +19,17 @@ struct gpt_entry_s {
 };
 typedef struct gpt_entry_s gpt_entry_t;
 
-gpt_context_t *gpt_init(const char *devname, unsigned int blocksize);
+#define GPT_INIT_FOR_WRITING	(1<<2)
+gpt_context_t *gpt_init(const char *devname, unsigned int blocksize, unsigned int flags);
 void gpt_finish(gpt_context_t *ctx);
 int gpt_fd(gpt_context_t *ctx);
 
-#define GPT_LOAD_BACKUP_ONLY	(1<<0)
+#define GPT_BACKUP_ONLY		(1<<0)
 #define GPT_NVIDIA_SPECIAL	(1<<1)
 
 int gpt_load(gpt_context_t *ctx, unsigned int flags);
 int gpt_load_from_config(gpt_context_t *ctx);
+int gpt_save(gpt_context_t *ctx, unsigned int flags);
 
 gpt_entry_t *gpt_find_by_name(gpt_context_t *ctx, const char *name);
 gpt_entry_t *gpt_enumerate_partitions(gpt_context_t *ctx, void **iterctx);

--- a/gpt.h
+++ b/gpt.h
@@ -1,5 +1,5 @@
-#ifndef gpt_h__
-#define gpt_h__
+#ifndef gpt_h_included
+#define gpt_h_included
 /* Copyright (c) 2019, Matthew Madison */
 
 #include <stdint.h>
@@ -34,4 +34,4 @@ int gpt_save(gpt_context_t *ctx, unsigned int flags);
 gpt_entry_t *gpt_find_by_name(gpt_context_t *ctx, const char *name);
 gpt_entry_t *gpt_enumerate_partitions(gpt_context_t *ctx, void **iterctx);
 
-#endif /* gpt_h__ */
+#endif /* gpt_h_included */

--- a/posix-crc32.h
+++ b/posix-crc32.h
@@ -1,5 +1,5 @@
-#ifndef posix_crc32_h__
-#define posix_crc32_h__
+#ifndef posix_crc32_h_included
+#define posix_crc32_h_included
 /* Copyright (c) 2020, Matthew Madison */
 
 #include <stddef.h>
@@ -7,4 +7,4 @@
 
 uint32_t posix_crc32(void *buf, size_t bufsiz);
 
-#endif /* posix_crc32_h__ */
+#endif /* posix_crc32_h_included */

--- a/smd.h
+++ b/smd.h
@@ -1,5 +1,5 @@
-#ifndef smd_h__
-#define smd_h__
+#ifndef smd_h_included
+#define smd_h_included
 /* Copyright (c) 2020, Matthew Madison */
 
 #include <stdbool.h>
@@ -33,4 +33,4 @@ int smd_slot_mark_active(smd_context_t *ctx, unsigned int which);
 int smd_get_current_slot(void);
 int smd_update(smd_context_t *ctx, gpt_context_t *boot_gpt, int bootfd, bool force);
 
-#endif /* smd_h__ */
+#endif /* smd_h_included */

--- a/tegra-boot-control.c
+++ b/tegra-boot-control.c
@@ -275,12 +275,12 @@ main (int argc, char * const argv[])
 		return 0;
 	}
 
-	gptctx = gpt_init(gptdev, 512);
+	gptctx = gpt_init(gptdev, 512, 0);
 	if (gptctx == NULL) {
 		perror("boot sector GPT");
 		return 1;
 	}
-	if (gpt_load(gptctx, GPT_LOAD_BACKUP_ONLY|GPT_NVIDIA_SPECIAL)) {
+	if (gpt_load(gptctx, GPT_BACKUP_ONLY|GPT_NVIDIA_SPECIAL)) {
 		fprintf(stderr, "Error: cannot load boot sector partition table\n");
 		gpt_finish(gptctx);
 		return 1;

--- a/tegra-bootinfo.c
+++ b/tegra-bootinfo.c
@@ -866,12 +866,12 @@ mark_nv_boot_successful (void)
 		perror("smd_get_current_slot");
 		return ret;
 	}
-	gptctx = gpt_init(gptdev, 512);
+	gptctx = gpt_init(gptdev, 512, 0);
 	if (gptctx == NULL) {
 		perror("gpt_init");
 		return ret;
 	}
-	if (gpt_load(gptctx, GPT_LOAD_BACKUP_ONLY|GPT_NVIDIA_SPECIAL)) {
+	if (gpt_load(gptctx, GPT_BACKUP_ONLY|GPT_NVIDIA_SPECIAL)) {
 		perror("gpt_load");
 		gpt_finish(gptctx);
 		return ret;

--- a/tegra-bootloader-update.c
+++ b/tegra-bootloader-update.c
@@ -287,7 +287,7 @@ update_bct (int bootfd, void *curbct, void *newbct, struct update_entry_s *ent)
 	bctslotsize = page_size * ((ent->length + (page_size-1)) / page_size);
 
 	for (i = 0; i < 3; i++) {
-		off_t offset;
+		off_t offset = 0;
 		switch (i) {
 			case 0:
 				offset = bctslotsize;

--- a/util.c
+++ b/util.c
@@ -1,0 +1,63 @@
+/*
+ * util.c
+ *
+ * Utility functions used in multiple places.
+ *
+ * Copyright (c) 2021, Matthew Madison
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "util.h"
+
+/*
+ * set_bootdev_writeable_status
+ *
+ * Toggles the read-only soft switch in sysfs for eMMC boot0/boot1
+ * devices, if present.
+ *
+ * bootdev: device name
+ * make_writeable: true for wrieable, false otherwise
+ *
+ * Returns: true if changed, false otherwise
+ *
+ */
+bool
+set_bootdev_writeable_status (const char *bootdev, bool make_writeable)
+{
+	char pathname[64];
+	char buf[1];
+	int fd, is_writeable, rc = 0;
+
+	if (bootdev == NULL)
+		return false;
+	if (strlen(bootdev) < 6 || strlen(bootdev) > 32)
+		return false;
+	sprintf(pathname, "/sys/block/%s/force_ro", bootdev + 5);
+	fd = open(pathname, O_RDWR);
+	if (fd < 0)
+		return false;
+	if (read(fd, buf, sizeof(buf)) != sizeof(buf)) {
+		close(fd);
+		return false;
+	}
+	make_writeable = !!make_writeable;
+	is_writeable = buf[0] == '0';
+	if (make_writeable && !is_writeable) {
+		if (write(fd, "0", 1) != 1)
+			rc = 1;
+	} else if (!make_writeable && is_writeable) {
+		if (write(fd, "1", 1) != 1)
+			rc = 1;
+	}
+	close(fd);
+
+	if (rc)
+		fprintf(stderr, "warning: could not change boot device write status\n");
+
+	return make_writeable != is_writeable;
+
+} /* set_bootdev_writeable_status */

--- a/util.h
+++ b/util.h
@@ -1,0 +1,8 @@
+#ifndef util_h__
+#define util_h__
+/* Copyright (c) 2021, Matthew Madison */
+
+#include <stdbool.h>
+bool set_bootdev_writeable_status(const char *bootdev, bool make_writeble);
+
+#endif /* util_h__ */

--- a/util.h
+++ b/util.h
@@ -1,8 +1,8 @@
-#ifndef util_h__
-#define util_h__
+#ifndef util_h_included
+#define util_h_included
 /* Copyright (c) 2021, Matthew Madison */
 
 #include <stdbool.h>
 bool set_bootdev_writeable_status(const char *bootdev, bool make_writeble);
 
-#endif /* util_h__ */
+#endif /* util_h_included */

--- a/ver.h
+++ b/ver.h
@@ -1,5 +1,5 @@
-#ifndef ver_h__
-#define ver_h__
+#ifndef ver_h_included
+#define ver_h_included
 /* Copyright (c) 2020, Matthew Madison */
 
 #include <time.h>
@@ -31,4 +31,4 @@ static inline __attribute__((unused)) unsigned int make_bsp_version(unsigned int
 
 int ver_extract_info (void *buf, size_t bufsiz, ver_info_t *ver);
 
-#endif /* ver_h__ */
+#endif /* ver_h_included */


### PR DESCRIPTION
Adds support for completely overwriting the boot device GPT as part of the initialization, using offsets and sizes from a configuration file.

This will allow a RAM-resident software installer to handle updates between L4T versions that change the layout of the boot device (and eMMC) by completely reformatting and repartitioning the storage at runtime.

Also includes some other minor cleanup and refactoring.