### PR TITLE
Partition presence check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,10 @@ dnl
 dnl Copyright (c) 2019-2021, Matthew Madison
 dnl
 
-AC_INIT([tegra-boot-tools], [2.3.1])
+AC_INIT([tegra-boot-tools], [2.3.2])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAJOR], [2], [Major version])
 AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MINOR], [3], [Minor version])
-AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [1], [Maintenance level])
+AC_DEFINE([TEGRA_BOOT_TOOLS_VERSION_MAINT], [2], [Maintenance level])
 AM_INIT_AUTOMAKE([subdir-objects foreign])
 AM_SILENT_RULES([yes])
 AC_COPYRIGHT([

--- a/tegra-bootloader-update.c
+++ b/tegra-bootloader-update.c
@@ -1334,8 +1334,11 @@ main (int argc, char * const argv[])
 			int redundant;
 			sprintf(pathname, "/dev/disk/by-partlabel/%s", partname);
 			if (access(pathname, F_OK|W_OK) != 0) {
-				fprintf(stderr, "Error: cannot locate partition: %s\n", partname);
-				goto reset_and_depart;
+				if (partition_should_be_present(partname)) {
+					fprintf(stderr, "Error: cannot locate partition: %s\n", partname);
+					goto reset_and_depart;
+				} else
+					continue;
 			}
 			strcpy(pathname_b, "/dev/disk/by-partlabel/");
 			sprintf(pathname_b + strlen(pathname_b), redundant_part_format(partname), partname);

--- a/util.c
+++ b/util.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <ctype.h>
 #include "util.h"
 
 #define MAX_PARTITIONS 256
@@ -94,8 +95,11 @@ partition_should_be_present (const char *partname)
 		FILE *fp = fopen(allpartconf, "r");
 		if (fp != NULL) {
 			char *name, *saveptr = NULL;
-			fread(partconf_buf, sizeof(partconf_buf[0]), sizeof(partconf_buf)/sizeof(partconf_buf[0]), fp);
+			size_t count = fread(partconf_buf, sizeof(partconf_buf[0]), sizeof(partconf_buf)/sizeof(partconf_buf[0])-1, fp);
 			fclose(fp);
+			while (count > 0 && isspace(partconf_buf[count-1]))
+				count -= 1;
+			partconf_buf[count] = '\0';
 			for (name = strtok_r(partconf_buf, ",", &saveptr);
 			     name != NULL && partcount < MAX_PARTITIONS;
 			     name = strtok_r(NULL, ",", &saveptr))
@@ -108,7 +112,7 @@ partition_should_be_present (const char *partname)
 	if (partcount == 0)
 		return true;
 	for (i = 0; i < partcount; i++)
-		if (strcmp(partname, partconf_list[i]))
+		if (strcmp(partname, partconf_list[i]) == 0)
 			return true;
 	return false;
 

--- a/util.h
+++ b/util.h
@@ -4,5 +4,6 @@
 
 #include <stdbool.h>
 bool set_bootdev_writeable_status(const char *bootdev, bool make_writeble);
+bool partition_should_be_present(const char *partname);
 
 #endif /* util_h_included */


### PR DESCRIPTION
Adds an `all-partitions.conf` config file (to be generated externally) to enumerate all of the partitions that *should* be present on the system. The list in that file is checked when a BUP entry is encountered for a partition that isn't actually present, and if the name isn't on the list, the missing entry is silently skipped.

Fixes #16.