### PR TITLE
tegra-boot-control: fix shortopt for Load

### DIFF
--- a/tegra-boot-control.c
+++ b/tegra-boot-control.c
@@ -34,7 +34,7 @@ static struct option options[] = {
 	{ "version",		no_argument,		0, 0   },
 	{ 0,			0,			0, 0   }
 };
-static const char *shortopts = ":cdema:si:D:h";
+static const char *shortopts = ":cdema:sL:D:h";
 
 static char *optarghelp[] = {
 	"--current-slot       ",


### PR DESCRIPTION
Apologies, I neglected to check the shortopts related to the last PR.