### PR TITLE
Use CMAKE_INSTALL_FULL_* for absolute paths

### DIFF
--- a/config-files/bootcountcheck.service.in
+++ b/config-files/bootcountcheck.service.in
@@ -8,7 +8,7 @@ Before=cryptsetup-pre.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_SBINDIR@/bootcountcheck
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/bootcountcheck
 
 [Install]
 WantedBy=sysinit.target

--- a/config-files/update_bootinfo.service.in
+++ b/config-files/update_bootinfo.service.in
@@ -6,7 +6,7 @@ ConditionPathExists=!@CMAKE_INSTALL_SYSCONFDIR@/initrd-release
 
 [Service]
 Type=oneshot
-ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/tegra-bootinfo -b
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/tegra-bootinfo -b
 RemainAfterExit=yes
 
 [Install]

--- a/tegra-boot-tools.pc.in
+++ b/tegra-boot-tools.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: tegra-boot-tools
 Version: @PROJECT_VERSION@


### PR DESCRIPTION
Instead of using a combination of CMAKE_INSTALL_PREFIX and
CMAKE_INSTALL_<dirname>, we should use CMAKE_INSTALL_FULL_<dirname>.

If the CMAKE_INSTALL_<dirname> is an absolute path (e.g. in NixOS), then
prefixing it with another absolute path would be incorrect.
CMAKE_INSTALL_FULL_<dirname> already handles the case if
CMAKE_INSTALL_<dirname> is an absolute path. See:
https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

Signed-off-by: Daniel Fullmer <danielrf12@gmail.com>