### PR TITLE
Add support for compatible TNSPECs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2021, Matthew Madison
+# Copyright (c) 2021-2023, Matthew Madison
 
 cmake_minimum_required(VERSION 3.8)
 cmake_policy(SET CMP0048 NEW)
 
-project(tegra_boot_tools LANGUAGES C VERSION 3.0.1)
+project(tegra_boot_tools LANGUAGES C VERSION 3.1.0)
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set_target_properties(tegra-boot-tools PROPERTIES
 target_include_directories(tegra-boot-tools PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/nvidia)
 target_link_libraries(tegra-boot-tools PUBLIC PkgConfig::ZLIB PkgConfig::UUID PkgConfig::TEGRA_EEPROM)
 target_compile_definitions(tegra-boot-tools PUBLIC "CONFIGPATH=${CMAKE_INSTALL_FULL_DATADIR}/tegra-boot-tools")
+target_compile_options(tegra-boot-tools PRIVATE -Wall -Werror)
 install(TARGETS tegra-boot-tools LIBRARY)
 
 add_executable(tegra-bootloader-update
@@ -134,14 +135,17 @@ add_executable(tegra-bootloader-update
   nvidia/t19x/nvboot_boot_component.h)
 target_include_directories(tegra-bootloader-update PRIVATE nvidia ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(tegra-bootloader-update PUBLIC tegra-boot-tools PkgConfig::TEGRA_EEPROM)
+target_compile_options(tegra-bootloader-update PRIVATE -Wall -Werror)
 
 add_executable(tegra-boot-control tegra-boot-control.c)
 target_include_directories(tegra-boot-control PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(tegra-boot-control PUBLIC tegra-boot-tools PkgConfig::TEGRA_EEPROM)
+target_compile_options(tegra-boot-control PRIVATE -Wall -Werror)
 
 add_executable(tegra-bootinfo tegra-bootinfo.c)
 target_include_directories(tegra-bootinfo PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(tegra-bootinfo PUBLIC tegra-boot-tools PkgConfig::ZLIB PkgConfig::TEGRA_EEPROM)
+target_compile_options(tegra-bootinfo PRIVATE -Wall -Werror)
 
 install(TARGETS tegra-boot-tools tegra-bootloader-update tegra-boot-control tegra-bootinfo RUNTIME)
 install(PROGRAMS scripts/bootcountcheck scripts/nvbootctrl scripts/nv_update_engine TYPE SBIN)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2021, Matthew Madison
+Copyright (c) 2019-2023, Matthew Madison
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bup.h
+++ b/bup.h
@@ -1,6 +1,6 @@
 #ifndef bup_h_included
 #define bup_h_included
-/* Copyright (c) 2019-2020, Matthew Madison */
+/* Copyright (c) 2019-2023, Matthew Madison */
 
 #include <sys/types.h>
 #include <stdbool.h>
@@ -15,6 +15,7 @@ void bup_finish(bup_context_t *ctx);
 const char *bup_gpt_device(bup_context_t *ctx);
 const char *bup_boot_device(bup_context_t *ctx);
 const char *bup_tnspec(bup_context_t *ctx);
+const char *bup_compat_spec(bup_context_t *ctx);
 bool bup_enumerate_entries(bup_context_t *ctx, void **iterctx,
 			   const char **partname, off_t *offset,
 			   size_t *length, unsigned int *version);

--- a/tegra-bootinfo.c
+++ b/tegra-bootinfo.c
@@ -452,7 +452,7 @@ int
 main (int argc, char * const argv[])
 {
 
-	int c, which, ret;
+	int c, which;
 	bool omitname = false;
 	bool force_init = false;
 	char *inputfile = NULL;

--- a/tegra-bootloader-update.c
+++ b/tegra-bootloader-update.c
@@ -1290,6 +1290,9 @@ main (int argc, char * const argv[])
 	redundant_entry_count = nonredundant_entry_count = 0;
 	largest_length = 0;
 	memset(&mb1_other, 0, sizeof(mb1_other));
+	printf("Native TNSPEC:   %s\n", bup_tnspec(bupctx));
+	if (bup_compat_spec(bupctx) != NULL)
+		printf("Compatible with: %s\n", bup_compat_spec(bupctx));
 	while (bup_enumerate_entries(bupctx, &bupiter, &partname, &offset, &length, &version)) {
 		gpt_entry_t *part, *part_b;
 		char partname_b[64], pathname_b[PATH_MAX];


### PR DESCRIPTION
This implements the equivalent of the `COMPATIBLE_SPEC` configuration in the stock L4T update tools, but the computation of the compatibility spec is directly coded, rather than implemented in a separate script and stored in a configuration file.

With this change, we can reduce the size of BUP payloads by including fewer variants, and support bootloader updates for new revisions of Jetson modules when those revisions have no impact on boot firmware compatibility.

Verified with:
  * Jetson TX1
  * Jetson Nano
  * Jetson Nano-eMMC
  * Jetson TX2
  * Jetson TX2-NX
  * Jetson Xavier NX
  * Jetson Xavier NX-eMMC
  * Jetson AGX Xavier
