### PR TITLE
Increase variable value buffer size 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.8)
 cmake_policy(SET CMP0048 NEW)
 
-project(tegra_boot_tools LANGUAGES C VERSION 3.1.0)
+project(tegra_boot_tools LANGUAGES C VERSION 3.1.1)
 
 include(GNUInstallDirs)
 

--- a/tegra-bootinfo.c
+++ b/tegra-bootinfo.c
@@ -311,7 +311,8 @@ show_bootvar (const char *name, bool omitname)
 	bootinfo_context_t *ctx;
 	bootinfo_var_iter_context_t *iter;
 	int rc = 0;
-	char namebuf[256], valuebuf[1024];
+	char namebuf[256];
+	static char valuebuf[65536];
 
 	if (bootinfo_open(BOOTINFO_O_RDONLY, &ctx) < 0) {
 		perror("bootinfo_open");
@@ -361,7 +362,7 @@ int
 set_bootvar (const char *name, const char *value, char *inputfile)
 {
 	bootinfo_context_t *ctx;
-	static char valuebuf[1024];
+	static char valuebuf[65536];
 	int rc = 0;
 
 	if (inputfile != NULL) {


### PR DESCRIPTION
The 1KiB buffer size into the tool is too small for some uses.  Increase to 64KiB.

Also bump version to 3.1.1 for next release.