### PR TITLE
Use appropriate buffer size when reading BUP file.

### DIFF
--- a/bup.c
+++ b/bup.c
@@ -108,8 +108,6 @@ struct bup_entry_s {
 	char spec[65];
 };
 
-#define BUFFERSIZE (1024 * 1024 * 1024)
-
 /*
  * API context
  */
@@ -551,7 +549,8 @@ free_context (bup_context_t *ctx)
 		close(ctx->fd);
 	if (ctx->entries)
 		free(ctx->entries);
-	free(ctx->buffer);
+	if (ctx->buffer != NULL)
+		free(ctx->buffer);
 	free(ctx);
 } /* free_context */
 
@@ -580,13 +579,8 @@ bup_init (const char *pathname)
 		return NULL;
 	memset(ctx, 0, sizeof(*ctx));
 	ctx->fd = -1;
-	ctx->buffer = malloc(BUFFERSIZE);
-	if (ctx->buffer == NULL) {
-		free(ctx);
-		return NULL;
-	}
 	if (construct_tnspec(ctx->our_spec_str, sizeof(ctx->our_spec_str)) < 0) {
-		free(ctx);
+		free_context(ctx);
 		return NULL;
 	}
 	spec_split(ctx->our_spec_str, &ctx->our_tnspec);
@@ -607,7 +601,14 @@ bup_init (const char *pathname)
 		return NULL;
 	}
 	payload_size = st.st_size;
-	n = read(fd, ctx->buffer, BUFFERSIZE);
+
+	ctx->buffer = malloc(payload_size);
+	if (ctx->buffer == NULL) {
+		free_context(ctx);
+		return NULL;
+	}
+
+	n = read(fd, ctx->buffer, payload_size);
 	if (n < sizeof(struct bup_header_s)) {
 		free_context(ctx);
 		return NULL;
@@ -637,7 +638,7 @@ bup_init (const char *pathname)
 		return NULL;
 	}
 	totsize = hdr->header_size + hdr->entry_count * sizeof(struct bup_ods_entry_s);
-	if (totsize > BUFFERSIZE) {
+	if (totsize > payload_size) {
 		fprintf(stderr, "%s: cannot load all update entries\n", pathname);
 		free_context(ctx);
 		return NULL;


### PR DESCRIPTION
Previously, a fixed 1GiB buffer was allocated causing the tool to use a lot of memory.

**Note: ** I haven't tested this yet. I'll test it out in the coming weeks and let you know the results. Best not to merge it beforehand. I'm just opening the pull request already so you can see if the code seems OK to you guys.